### PR TITLE
Update runtime to 25.08

### DIFF
--- a/com.xiaoyaocz.simple_live.yaml
+++ b/com.xiaoyaocz.simple_live.yaml
@@ -1,20 +1,13 @@
 app-id: com.xiaoyaocz.simple_live
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: simple_live
-add-extensions:
-  org.freedesktop.Platform.ffmpeg-full:
-    version: '24.08'
-    directory: lib/ffmpeg
-    add-ld-path: .
 cleanup:
   - /include
   - /lib/pkgconfig
   - /share/man
   - /share/doc
-cleanup-commands:
-  - mkdir -p ${FLATPAK_DEST}/lib/ffmpeg
 separate-locales: false
 finish-args:
   - --share=ipc


### PR DESCRIPTION
### Update runtime to 25.08

Use the latest runtime

### Drop ffmpeg extension

Freedesktop runtime version 25.08 (also GNOME runtime 49, KDE runtime 6.10, and 5.15-25.08) provides FFMPEG; therefore, declaring **org.freedesktop.Platform.ffmpeg-full** extension is no longer required.

Fixes: https://github.com/flathub/com.xiaoyaocz.simple_live/issues/18